### PR TITLE
updated particles to latest version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,8 +16,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-ga": "^2.7.0",
-    "react-particles-js": "^3.1.0",
-    "react-progressive-image": "^0.6.0"
+    "react-progressive-image": "^0.6.0",
+    "react-tsparticles": "^1.17.9"
   },
   "devDependencies": {
     "@types/node": "^13.13.2",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IParticlesParams } from "react-particles-js";
+import { IParticlesParams, OutMode } from "react-tsparticles";
 import dynamic from "next/dynamic";
 import Icon from "@mdi/react";
 import { mdiApple, mdiGithub, mdiLinux, mdiMicrosoftWindows } from "@mdi/js";
@@ -7,20 +7,30 @@ import Head from "next/head";
 import ProgressiveImage from "react-progressive-image";
 import axios from "axios";
 
-const Particles = dynamic(() => import("react-particles-js"), {
+const Particles = dynamic(() => import("react-tsparticles"), {
   ssr: false,
 });
 
 const params: IParticlesParams = {
   detectRetina: true,
   particles: {
+    collisions: {
+      enable: true,
+    },
     opacity: {
       value: 0.1,
     },
     number: {
       value: 100,
     },
-    lineLinked: { enable: false },
+    links: {
+      enable: false,
+    },
+    move: {
+      enable: true,
+      speed: 3,
+      outMode: OutMode.bounce,
+    },
     size: {
       value: 5,
     },
@@ -64,7 +74,7 @@ export default ({ macUrl, linuxUrl }) => {
         />
         <meta property="og:image" content="https://getmoose.in/favicon.png" />
       </Head>
-      <Particles className={"particles"} params={params} />
+      <Particles className={"particles"} options={params} />
 
       <div className="banner">
         <div className="top-section">

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3182,6 +3182,11 @@ lodash@^4.17.11, lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -4304,18 +4309,18 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-particles-js@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-particles-js/-/react-particles-js-3.1.0.tgz#00d80ba957111e69bd0247eef343b7ac9a388695"
-  integrity sha512-YZVwXXE8qYav7Hk4Rj+U8I8R8bLKNI6RPQLbruI3e+oHvZ2G7YzLmNdxFC6K3WqQO61YP2lemZSfdK26x9rAYA==
-  dependencies:
-    lodash "^4.17.11"
-    tsparticles "^1.12.11"
-
 react-progressive-image@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-progressive-image/-/react-progressive-image-0.6.0.tgz#56b1c7153a6e1ebbe2a3bbf8f98c37410fbc67c2"
   integrity sha512-/yc8N3lHskPQkubm+QH5RIQHA89Sigv7p9UkvbHzKVE2OBb6njhmquk7GW/f2Y//mzk5DesFHN/hV5RWhd6IXA==
+
+react-tsparticles@^1.17.9:
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/react-tsparticles/-/react-tsparticles-1.17.9.tgz#b0f3a105c63ca7cfca28e281e7ad9d521e087bce"
+  integrity sha512-x+ie181WAPAGb65iIXYMixigu1sHbW2qd5+88WpjZodgAq/rY0AgFrAfWUsIf50zIPU7oLBFJTSjE6q5UJ18mw==
+  dependencies:
+    lodash "^4.17.19"
+    tsparticles "^1.17.9"
 
 react@^16.13.1:
   version "16.13.1"
@@ -5046,12 +5051,18 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tsparticles@^1.12.11:
-  version "1.12.11"
-  resolved "https://registry.yarnpkg.com/tsparticles/-/tsparticles-1.12.11.tgz#4b3756fb377a01cec8cd89b1b8237fbb96aa504f"
-  integrity sha512-77eEoc+aFtimGNQJQHwVAsjg8qYaDV0ehIwQSNWbI2b1cTQZrnV4uR2Pk5ic8IdSht4SULkNQmVhvjAoH0nZ4Q==
+tslib@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tsparticles@^1.17.9:
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/tsparticles/-/tsparticles-1.17.9.tgz#91893cb3e53b7a29518f347ab2c0421071ce6d83"
+  integrity sha512-jRu7OWAGqXPhFVb8ZW8NmEpEmEdSnN9dZ/xalg1izv8VwynqgMPTVYEQH2Nh1BYmVjbTyBvKnk0kiLHgDzn3Hw==
   dependencies:
     pathseg "^1.2.0"
+    tslib "^2.0.0"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
The updated particles has a better collision animation.
I updated it to `react-tsparticles` just because it uses the [tsparticles](https://github.com/matteobruni/tsparticles) latest version, `react-particles-js` is some versions behind