### PR TITLE
fixed the flashing of scrollbar on window resize

### DIFF
--- a/renderer/components/Downloads/Downloads.module.scss
+++ b/renderer/components/Downloads/Downloads.module.scss
@@ -46,11 +46,6 @@
   padding: 5px !important;
 }
 
-.simplebar {
-  display: flex;
-  overflow: auto;
-}
-
 .tdDisabled {
   opacity: 0.6;
   pointer-events: none;

--- a/renderer/components/Downloads/Downloads.tsx
+++ b/renderer/components/Downloads/Downloads.tsx
@@ -92,7 +92,7 @@ export const Downloads: React.FC<IProps> = memo(
 
     return (
       <div className={styles.results}>
-        <SimpleBar className={styles.simplebar}>
+        <SimpleBar>
           <div className={styles.resultsTableWrapper}>
             {fadeInTranslateY(!!data.length).map(
               ({ item, props, key }) =>


### PR DESCRIPTION
Followed the recommendations in the SimpleBar repository's issues and fixed the blinking scrollbar glitch. The CSS rule that caused the bug was the `overflow: auto `, but since `display: flex` had no impact on the layout, I've removed it aswell.